### PR TITLE
Add patch note support via localized strings to mct

### DIFF
--- a/script/groovy/modules/mct/objects/mods/obj.lua
+++ b/script/groovy/modules/mct/objects/mods/obj.lua
@@ -12,6 +12,9 @@ local log,logf,err,errf = get_vlog("[mct]")
 local mct_mod_defaults = {
     ---@type string The key for this mod object.
     _key = "",
+    
+    ---@type string the cached patchnotes of this mod
+    _patch_notes = nil,
 
     ---@type table The patches created for this mod - the various patches and the relative dates and info. Highest index is the most recent, first index is the first one made.
     _patches = {},
@@ -241,6 +244,27 @@ end
 ---@return number
 function mct_mod:get_version_number()
     return self._version[1]
+end
+
+---@return string
+function mct_mod:get_patch_notes()
+    if nil ~= self._patch_notes then
+        return self._patch_notes;
+    end;
+    self._patch_notes = "";
+    local parts = {};
+    for i = self._version[1], 1, -1 do
+        local version_text = common.get_localised_string("mct_patch_notes_"..i.."_version")
+        local notes = common.get_localised_string("mct_patch_notes_"..i.."_notes")
+        if version_text == "" then
+            version_text = "i"..i
+        end;
+        if notes ~= "" then
+            parts[#parts + 1] = version_text.."\n"..notes
+        end;
+    end;
+    self._patch_notes = table.concat(parts, "\n\n")
+    return self._patch_notes;
 end
 
 function mct_mod:set_main_image(path, w, h)

--- a/script/groovy/modules/mct/objects/mods/obj.lua
+++ b/script/groovy/modules/mct/objects/mods/obj.lua
@@ -254,8 +254,8 @@ function mct_mod:get_patch_notes()
     self._patch_notes = "";
     local parts = {};
     for i = self._version[1], 1, -1 do
-        local version_text = common.get_localised_string("mct_patch_notes_"..i.."_version")
-        local notes = common.get_localised_string("mct_patch_notes_"..i.."_notes")
+        local version_text = common.get_localised_string("mct_patch_notes_"..self:get_key().."_"..i.."_version")
+        local notes = common.get_localised_string("mct_patch_notes_"..self:get_key().."_"..i.."_notes")
         if version_text == "" then
             version_text = "i"..i
         end;

--- a/script/groovy/modules/mct/objects/page/types/Main.lua
+++ b/script/groovy/modules/mct/objects/page/types/Main.lua
@@ -229,6 +229,33 @@ function Main:populate_main_view()
         )
     end
 
+    if mod_obj:get_patch_notes() ~= "" then
+        self:add_tab(
+            "patch_notes", 
+            "Patch Notes", 
+            "View the mod's patch notes",
+            function(uic)
+                local list = core:get_or_create_component("list_view", "ui/groovy/layouts/listview", uic)
+                list:Resize(uic:Width(), uic:Height())
+                list:SetDockingPoint(2)
+
+                local list_box = find_uicomponent(list, "list_clip", "list_box")
+                local txt = core:get_or_create_component("patch_notes_text", "ui/groovy/text/fe_default", list_box)
+
+                txt:Resize(uic:Width() - 10, uic:Height() - 10)
+
+                txt:SetDockingPoint(2)
+                txt:SetTextXOffset(5, 5)
+                txt:SetTextYOffset(5, 5)
+                txt:SetStateText(mod_obj:get_patch_notes())
+                txt:SetTextVAlign("top")
+
+                local tw, th = txt:TextDimensions()
+                txt:Resize(tw, th)
+            end
+        )
+    end
+
     -- If the mod obj has a changelog, add a changelog tab.
     -- if mod_obj:get_changelog() ~= "" then
     --     create_tab("changelog", "Changelog", "View the mod's changelog.")


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/adbbbb56-f00a-404f-82a6-d128ccd60c2e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/947cf961-88b0-4c1e-afd6-a7f5e4e5153b" />

Patchnotes are retrieved from the localization from numeric version(i.e. upload number) down to 1 and will display if there are patch notes. The version is optional and will, if not given, be replaced by an iteration count marker.

`mct_patch_notes_{key}_{iteration}_version` - version name, optional
`mct_patch_notes_{key}_{iteration}_notes` - the actual patch notes, required for displaying